### PR TITLE
Rework nullability

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,7 +108,7 @@
   branch = "master"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
-  revision = "1c35d901db3da928c72a72d8458480cc9ade058f"
+  revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
   name = "github.com/json-iterator/go"
@@ -129,6 +129,12 @@
   version = "1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mohae/deepcopy"
+  packages = ["."]
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -143,8 +149,8 @@
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
-  version = "v1.0.4"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -159,13 +165,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
+  revision = "c7dcf104e3a7a1417abc0230cb0d5240d764159d"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "d25186b37f34ebdbbea8f488ef055638dfab272d"
+  revision = "ae89d30ce0c63142b652837da33d782e2b0a9b25"
 
 [[projects]]
   branch = "master"
@@ -174,7 +180,7 @@
     "unix",
     "windows"
   ]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  revision = "7dca6fe1f43775aa6d1334576870ff63f978f539"
 
 [[projects]]
   name = "gopkg.in/go-playground/validator.v9"
@@ -185,6 +191,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cb96de3a2ebd0b87059576f6e170a683af0e06efa034b0bb895c88c6eaf52796"
+  inputs-digest = "03fb1f694df95f7e2bb00b647ea60d77cec0ae25fe8ec8a55a8c6d3951303f97"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/base_field.go
+++ b/internal/base_field.go
@@ -20,8 +20,7 @@ type baseField struct {
 	jsonapiExported  bool
 	jsonapiOmitempty bool
 
-	sqlNotnull bool
-	sqlUnique  bool
+	sqlUnique bool
 
 	jsonapiF []reflect.StructField
 	pgF      []reflect.StructField
@@ -90,8 +89,6 @@ func newBaseField(schema *Schema, f *reflect.StructField) *baseField {
 				panic(errJsonapiOptionOnUnexportedField)
 			}
 			field.jsonapiOmitempty = parseBoolOption(value)
-		case optionNotnull:
-			field.sqlNotnull = parseBoolOption(value)
 		case optionUnique:
 			field.sqlUnique = parseBoolOption(value)
 		}

--- a/internal/base_field.go
+++ b/internal/base_field.go
@@ -35,7 +35,7 @@ func (f *baseField) Writable() bool {
 }
 
 func (f *baseField) Sortable() bool {
-	return f.jargoSortable
+	return f.jargoSortable && !isNullable(f.fieldType)
 }
 
 func (f *baseField) Filterable() bool {

--- a/internal/belongs_field.go
+++ b/internal/belongs_field.go
@@ -67,7 +67,7 @@ func pgBelongsToFields(f *belongsToField, joinField bool) []reflect.StructField 
 	// every belongsTo association has a column containing
 	// the id of the related resource
 	tag := fmt.Sprintf(`sql:"%s`, f.relationIdFieldColumn())
-	if f.sqlNotnull {
+	if !isNullable(f.fieldType) {
 		tag += ",notnull"
 	}
 	if f.sqlUnique {

--- a/internal/belongs_field.go
+++ b/internal/belongs_field.go
@@ -67,7 +67,7 @@ func pgBelongsToFields(f *belongsToField, joinField bool) []reflect.StructField 
 	// every belongsTo association has a column containing
 	// the id of the related resource
 	tag := fmt.Sprintf(`sql:"%s`, f.relationIdFieldColumn())
-	if !isNullable(f.fieldType) {
+	if !f.nullable {
 		tag += ",notnull"
 	}
 	if f.sqlUnique {
@@ -242,7 +242,7 @@ func (i *belongsToFieldInstance) applyToJoinResourceModel(instance *resourceMode
 
 	rmi := v.toJoinResourceModel()
 
-	instance.value.Elem().FieldByName(i.field.fieldName).Set(reflect.ValueOf(rmi))
+	instance.value.Elem().FieldByName(i.field.fieldName).Set(reflect.ValueOf(rmi).Elem())
 }
 
 // relationId returns the id value of the relation.

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -22,7 +22,6 @@ const (
 	optionSort      = "sort"
 	optionFilter    = "filter"
 	optionOmitempty = "omitempty"
-	optionNotnull   = "notnull"
 	optionUnique    = "unique"
 	optionDefault   = "default"
 	optionCreatedAt = "createdAt"

--- a/internal/relation_field.go
+++ b/internal/relation_field.go
@@ -16,8 +16,10 @@ type relationField struct {
 
 	registry SchemaRegistry
 
-	relationType reflect.Type // struct type of relation
-	collection   bool         // whether it's a to-many-relation
+	// relationType is the direct struct type of the relation,
+	// e.g. *User -> User, []*User -> User
+	relationType reflect.Type
+	collection   bool // whether it's a to-many-relation
 }
 
 func newRelationField(r SchemaRegistry, schema *Schema, f *reflect.StructField) *relationField {

--- a/internal/relation_field.go
+++ b/internal/relation_field.go
@@ -7,9 +7,7 @@ import (
 	"reflect"
 )
 
-func errInvalidRelationFieldType(p reflect.Type) error {
-	return errors.New(fmt.Sprintf("invalid type for relation field: %s", p))
-}
+var errInvalidRelationFieldType = errors.New("relation field types must be a struct type, a pointer to a struct type or a slice of a struct type")
 
 type relationField struct {
 	*baseField
@@ -19,46 +17,49 @@ type relationField struct {
 	// relationType is the direct struct type of the relation,
 	// e.g. *User -> User, []*User -> User
 	relationType reflect.Type
-	collection   bool // whether it's a to-many-relation
+	// whether it's a to-many-relation
+	collection bool
+	// whether the relation is nullable
+	nullable bool
 }
 
 func newRelationField(r SchemaRegistry, schema *Schema, f *reflect.StructField) *relationField {
 	base := newBaseField(schema, f)
 
 	// validate field type
-	typ, collection := getRelationType(f.Type)
+	typ, collection, nullable := getRelationType(f.Type)
 	if typ == nil {
-		panic(errInvalidRelationFieldType(f.Type))
+		panic(errInvalidRelationFieldType)
 	}
 
-	field := &relationField{
+	return &relationField{
 		baseField:    base,
 		registry:     r,
 		relationType: typ,
 		collection:   collection,
+		nullable:     nullable,
 	}
-
-	return field
 }
 
-func getRelationType(typ reflect.Type) (reflect.Type, bool) {
-	collection := false
+// getRelationType returns typ's struct type, whether it's a collection
+// and whether it's nullable.
+// If the returned Type is nil, typ is not a struct type, or it is
+// a collection of pointers (which is pointless to have).
+func getRelationType(typ reflect.Type) (structType reflect.Type, collection bool, nullable bool) {
 	if typ.Kind() == reflect.Slice {
 		typ = typ.Elem()
 		collection = true
-	}
-
-	if typ.Kind() == reflect.Ptr {
+	} else if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
-	} else {
-		return nil, false
+		nullable = true
 	}
 
-	if typ.Kind() != reflect.Struct {
-		return nil, false
+	if typ.Kind() == reflect.Struct {
+		structType = typ
+		return
 	}
 
-	return typ, collection
+	return nil, false, false
 }
 
 func (f *belongsToField) Writable() bool {
@@ -185,14 +186,20 @@ func (i *relationFieldInstance) applyToResourceModel(instance *resourceModelInst
 		for x := 0; x < l; x++ {
 			v := i.values[x]
 			if v != nil {
-				values.Index(x).Set(reflect.ValueOf(v.toJoinResourceModel()))
+				values.Index(x).Set(reflect.ValueOf(v.toJoinResourceModel()).Elem())
 			}
 		}
 		val.Set(values)
 	} else {
 		v := i.values[0]
 		if v != nil {
-			val.Set(reflect.ValueOf(v.toJoinResourceModel()))
+			joinModel := reflect.ValueOf(v.toJoinResourceModel())
+			if !i.field.nullable {
+				// if the field is not nullable,
+				// we need the struct type instead of the pointer type
+				joinModel = joinModel.Elem()
+			}
+			val.Set(joinModel)
 		}
 	}
 }

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -234,6 +234,15 @@ func (s *Schema) ParseResourceModel(instance interface{}) *SchemaInstance {
 
 func (s *Schema) parseJoinResourceModel(instance interface{}) *SchemaInstance {
 	v := reflect.ValueOf(instance)
+
+	// if instance is not a pointer,
+	// wrap it in a pointer
+	if v.Type() == s.resourceModelType {
+		ptr := reflect.New(v.Type())
+		ptr.Elem().Set(v)
+		v = ptr
+	}
+
 	if v.Type() != reflect.PtrTo(s.resourceModelType) {
 		panic(errInvalidResourceInstance)
 	}

--- a/internal/schema_field.go
+++ b/internal/schema_field.go
@@ -43,22 +43,22 @@ type schemaFieldInstance interface {
 	// Only implemented for fields that may be sortable.
 	sortValue() interface{}
 
-	// parses a resource model instance, setting the field's value.
+	// parses a resource model instance, storing it's value for the schema field.
 	parseResourceModel(*resourceModelInstance)
-	// parses a jsonapi model instance, setting the field's value.
+	// parses a jsonapi model instance, storing it's value for the schema field.
 	parseJsonapiModel(*jsonapiModelInstance)
-	// parses a resource model instance, setting the field's value.
+	// parses a resource model instance, storing it's value for the schema field.
 	parsePGModel(*pgModelInstance)
 
 	parseJoinResourceModel(*resourceModelInstance)
 	parseJoinJsonapiModel(*joinJsonapiModelInstance)
 	parseJoinPGModel(*joinPGModelInstance)
 
-	// applies the field's value to a resource model instance.
+	// applies the stored value to a resource model instance.
 	applyToResourceModel(*resourceModelInstance)
-	// applies the field's value to a resource model instance.
+	// applies the stored value to a jsonapi model instance.
 	applyToJsonapiModel(*jsonapiModelInstance)
-	// applies the field's value to a resource model instance.
+	// applies the stored value to a pg model instance.
 	applyToPGModel(*pgModelInstance)
 
 	applyToJoinResourceModel(*resourceModelInstance)

--- a/query.go
+++ b/query.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
+	"github.com/mohae/deepcopy"
 	"net/http"
 	"reflect"
 )
@@ -50,12 +51,17 @@ type Query struct {
 }
 
 func newQuery(db orm.DB, resource *Resource, typ queryType, collection bool, pgModelInstance interface{}) *Query {
+	// deepcopy the pg model instance passed
+	// to ensure the original data is not being
+	// modified if it has pointer references
+	clone := deepcopy.Copy(pgModelInstance)
+
 	return &Query{
-		Query:      db.Model(pgModelInstance),
+		Query:      db.Model(clone),
 		typ:        typ,
 		resource:   resource,
 		collection: collection,
-		model:      reflect.ValueOf(pgModelInstance),
+		model:      reflect.ValueOf(clone),
 	}
 }
 

--- a/test/integration/auto_timestamps_test.go
+++ b/test/integration/auto_timestamps_test.go
@@ -12,8 +12,8 @@ import (
 type AutoTimestamps struct {
 	Id int64 `jargo:"auto_timestamps,alias:auto_timestamp"`
 
-	CreatedAt time.Time `jargo:",createdAt"`
-	UpdatedAt time.Time `jargo:",updatedAt"`
+	CreatedAt *time.Time `jargo:",createdAt"`
+	UpdatedAt *time.Time `jargo:",updatedAt"`
 
 	Name string
 }
@@ -31,8 +31,8 @@ func TestAutoTimestamps(t *testing.T) {
 	instance := r.(*AutoTimestamps)
 	assert.Equal(t, "A", instance.Name)
 	// instance.CreatedAt and instance.UpdatedAt should have been populated by the server
-	assert.NotEmpty(t, instance.CreatedAt)
-	assert.NotEmpty(t, instance.UpdatedAt)
+	assert.NotNil(t, instance.CreatedAt)
+	assert.NotNil(t, instance.UpdatedAt)
 	assert.Equal(t, instance.CreatedAt, instance.UpdatedAt)
 
 	// wait a short amount of time to ensure
@@ -47,10 +47,10 @@ func TestAutoTimestamps(t *testing.T) {
 	assert.Equal(t, "B", updated.Name)
 
 	// instance.CreatedAt should not have changed
-	assert.NotEmpty(t, updated.CreatedAt)
+	assert.NotNil(t, updated.CreatedAt)
 	assert.Equal(t, instance.CreatedAt, updated.CreatedAt)
 
 	// instance.UpdatedAt should be updated timestamp
-	assert.NotEmpty(t, updated.UpdatedAt)
+	assert.NotNil(t, updated.UpdatedAt)
 	assert.NotEqual(t, instance.UpdatedAt, updated.UpdatedAt)
 }

--- a/test/integration/nullable_test.go
+++ b/test/integration/nullable_test.go
@@ -1,0 +1,53 @@
+// +build integration
+
+package integration
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type nullableRelation struct {
+	Id       int64
+	Relation *dummy `jargo:",belongsTo,nullable"`
+}
+
+type nonNullableRelation struct {
+	Id       int64
+	Relation *dummy `jargo:",belongsTo"`
+}
+
+// TestNullableRelations tests the behaviour of nullable relation fields.
+func TestNullableRelations(t *testing.T) {
+	resource, err := app.RegisterResource(nullableRelation{})
+	require.Nil(t, err)
+
+	// insert nullableRelation instance with relation set to null
+	_, err = resource.InsertInstance(app.DB(), &nullableRelation{}).Result()
+	require.Nil(t, err)
+
+	// insert nullableRelation instance with relation set to value
+	res, err := resource.InsertInstance(app.DB(),
+		&nullableRelation{Relation: dummyInstance}).
+		Result()
+	require.Nil(t, err)
+	require.Equal(t, res.(*nullableRelation).Relation.Id, dummyInstance.Id)
+}
+
+// TestNonNullableRelations tests the behaviour of non-nullable (default)
+// relation fields.
+func TestNonNullableRelations(t *testing.T) {
+	resource, err := app.RegisterResource(nonNullableRelation{})
+	require.Nil(t, err)
+
+	// insert nonNullableRelation instance with relation set to value
+	res, err := resource.InsertInstance(app.DB(),
+		&nonNullableRelation{Relation: dummyInstance}).
+		Result()
+	require.Nil(t, err)
+	require.Equal(t, res.(*nonNullableRelation).Relation.Id, dummyInstance.Id)
+
+	// insert nonNullableRelation instance with relation set to null
+	_, err = resource.InsertInstance(app.DB(), &nonNullableRelation{}).Result()
+	require.EqualError(t, err, "encountered null value on belongsTo relation not marked nullable")
+}

--- a/test/integration/nullable_test.go
+++ b/test/integration/nullable_test.go
@@ -7,14 +7,44 @@ import (
 	"testing"
 )
 
+type nullableAttribute struct {
+	Id   int64
+	Name *string
+	Age  *int
+}
+
 type nullableRelation struct {
 	Id       int64
-	Relation *dummy `jargo:",belongsTo,nullable"`
+	Relation *dummy `jargo:",belongsTo"`
 }
 
 type nonNullableRelation struct {
 	Id       int64
-	Relation *dummy `jargo:",belongsTo"`
+	Relation dummy `jargo:",belongsTo"`
+}
+
+type nullableIdField struct {
+	Id *int64 // this is invalid
+}
+
+// TestNullableAttributes tests the behaviour of nullable attribute fields.
+func TestNullableAttributes(t *testing.T) {
+	resource, err := app.RegisterResource(nullableAttribute{})
+	require.Nil(t, err)
+
+	// insert instance with attribute set to null
+	age := 20
+	_, err = resource.InsertInstance(app.DB(), &nullableAttribute{
+		Name: nil,
+		Age:  &age,
+	}).Result()
+	require.Nil(t, err)
+}
+
+// TestNullableIdFields tests the behaviour of nullable id fields (which is invalid).
+func TestNullableIdFields(t *testing.T) {
+	_, err := app.RegisterResource(nullableIdField{})
+	require.EqualError(t, err, "id field must not be nullable")
 }
 
 // TestNullableRelations tests the behaviour of nullable relation fields.
@@ -42,7 +72,7 @@ func TestNonNullableRelations(t *testing.T) {
 
 	// insert nonNullableRelation instance with relation set to value
 	res, err := resource.InsertInstance(app.DB(),
-		&nonNullableRelation{Relation: dummyInstance}).
+		&nonNullableRelation{Relation: *dummyInstance}).
 		Result()
 	require.Nil(t, err)
 	require.Equal(t, res.(*nonNullableRelation).Relation.Id, dummyInstance.Id)

--- a/test/integration/nullable_test.go
+++ b/test/integration/nullable_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"github.com/stretchr/testify/require"
+	"reflect"
 	"testing"
 )
 
@@ -34,18 +35,33 @@ func TestNullableAttributes(t *testing.T) {
 
 	// insert instance with attribute set to null
 	age := 20
-	_, err = resource.InsertInstance(app.DB(), &nullableAttribute{
+	original := &nullableAttribute{
 		Name: nil,
 		Age:  &age,
-	}).Result()
+	}
+	res, err := resource.InsertInstance(app.DB(), original).Result()
 	require.Nil(t, err)
+
+	inserted := res.(*nullableAttribute)
+	// ensure age pointer of returned instance points to different address
+	require.NotEqual(t, reflect.ValueOf(inserted.Age).Pointer(), reflect.ValueOf(original.Age).Pointer())
+
+	// fetch created resource from database to ensure data was properly stored
+	res, err = resource.SelectById(app.DB(), inserted.Id).Result()
+	require.Nil(t, err)
+	fetched := res.(*nullableAttribute)
+
+	require.Equal(t, fetched.Age, original.Age)
+	require.Equal(t, fetched.Name, original.Name)
 }
 
+/* TODO: re-introduce this check when implementing support for non-int64 id fields
 // TestNullableIdFields tests the behaviour of nullable id fields (which is invalid).
 func TestNullableIdFields(t *testing.T) {
 	_, err := app.RegisterResource(nullableIdField{})
 	require.EqualError(t, err, "id field must not be nullable")
 }
+*/
 
 // TestNullableRelations tests the behaviour of nullable relation fields.
 func TestNullableRelations(t *testing.T) {

--- a/test/integration/relation_test.go
+++ b/test/integration/relation_test.go
@@ -1,0 +1,90 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type oneToManyA struct {
+	Id   int64
+	Attr string
+	Bs   []oneToManyB `jargo:",has:A"`
+}
+
+type oneToManyB struct {
+	Id int64
+	A  oneToManyA `jargo:",belongsTo"`
+}
+
+// TestOneToManyRelations tests the behaviour of one-to-many relations.
+func TestOneToManyRelations(t *testing.T) {
+	resourceA, err := app.RegisterResource(oneToManyA{})
+	require.Nil(t, err)
+
+	resourceB, err := app.RegisterResource(oneToManyB{})
+	require.Nil(t, err)
+
+	// create instance of oneToManyA
+	res, err := resourceA.InsertInstance(app.DB(), &oneToManyA{Attr: "test"}).Result()
+	require.Nil(t, err)
+	a := res.(*oneToManyA)
+
+	// create instance of oneToManyB with relation to a
+	res, err = resourceB.InsertInstance(app.DB(), &oneToManyB{A: *a}).Result()
+	require.Nil(t, err)
+	b := res.(*oneToManyB)
+
+	// ensure relation is properly set
+	require.Equal(t, a.Id, b.A.Id)
+	require.Equal(t, a.Attr, b.A.Attr)
+
+	// fetch oneToManyA to update relations
+	res, err = resourceA.SelectById(app.DB(), a.Id).Result()
+	require.Nil(t, err)
+	a = res.(*oneToManyA)
+
+	// ensure relation is properly set
+	require.Equal(t, b.Id, a.Bs[0].Id)
+}
+
+type oneToOneA struct {
+	Id   int64
+	Attr string
+	B    *oneToOneB `jargo:",has:A"`
+}
+
+type oneToOneB struct {
+	Id int64
+	A  oneToOneA `jargo:",belongsTo"`
+}
+
+// TestOneToOneRelations tests the behaviour of one-to-one relations.
+func TestOneToOneRelations(t *testing.T) {
+	resourceA, err := app.RegisterResource(oneToOneA{})
+	require.Nil(t, err)
+
+	resourceB, err := app.RegisterResource(oneToOneB{})
+	require.Nil(t, err)
+
+	// create instance of oneToOneA
+	res, err := resourceA.InsertInstance(app.DB(), &oneToOneA{Attr: "test"}).Result()
+	require.Nil(t, err)
+	a := res.(*oneToOneA)
+
+	// create instance of oneToManyB with relation to a
+	res, err = resourceB.InsertInstance(app.DB(), &oneToOneB{A: *a}).Result()
+	require.Nil(t, err)
+	b := res.(*oneToOneB)
+
+	// ensure relation is properly set
+	require.Equal(t, a.Id, b.A.Id)
+	require.Equal(t, a.Attr, b.A.Attr)
+
+	// fetch oneToManyA to update relations
+	res, err = resourceA.SelectById(app.DB(), a.Id).Result()
+	require.Nil(t, err)
+	a = res.(*oneToOneA)
+
+	// ensure relation is properly set
+	require.Equal(t, b.Id, a.B.Id)
+}


### PR DESCRIPTION
Removed the `notnull` struct tag option in favor of using pointer types for nullable fields.
This circumvents `go-pg` setting a column value to `NULL` for the zero values of primitive types by being able to explicitly add `notnull` to the generated `go-pg` struct fields if the field type is a primitive type.

Fixes and closes #16.