### PR TITLE
Add support for more id field types

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/crushedpixel/jargo/internal"
 	"github.com/go-pg/pg/orm"
-	"strconv"
 	"strings"
 )
 
@@ -22,13 +21,13 @@ type Filters struct {
 // via a logical OR, and all of the values for
 // an operator being connected via a logical AND.
 type Filter struct {
-	Eq   []string
-	Not  []string
-	Like []string
-	Lt   []string
-	Lte  []string
-	Gt   []string
-	Gte  []string
+	Eq   []interface{}
+	Not  []interface{}
+	Like []interface{}
+	Lt   []interface{}
+	Lte  []interface{}
+	Gt   []interface{}
+	Gte  []interface{}
 }
 
 func newFilters(r *Resource, filters map[internal.SchemaField]*Filter) *Filters {
@@ -55,7 +54,7 @@ func (f *Filter) applyToQuery(q *orm.Query, field internal.SchemaField) {
 }
 
 // generates an AND WHERE (xxx OR xxx) clause
-func andWhereOr(q *orm.Query, field internal.SchemaField, op string, values []string) {
+func andWhereOr(q *orm.Query, field internal.SchemaField, op string, values []interface{}) {
 	if len(values) > 0 {
 		q.WhereGroup(func(q *orm.Query) (*orm.Query, error) {
 			for _, val := range values {
@@ -76,7 +75,7 @@ func andWhereOr(q *orm.Query, field internal.SchemaField, op string, values []st
 // using ParseFilterParameters.
 //
 // Returns ErrInvalidQueryParams when encountering invalid query values.
-func (r *Resource) ParseFilters(parsed map[string]map[string][]string) (*Filters, error) {
+func (r *Resource) ParseFilters(parsed map[string]map[string][]interface{}) (*Filters, error) {
 	// convert parsed data into Filter map
 	f := make(map[string]*Filter)
 	for field, filters := range parsed {
@@ -142,8 +141,8 @@ func (r *Resource) Filters(filters map[string]*Filter) (*Filters, error) {
 }
 
 // IdFilter returns a Filters instance filtering by the id field.
-func (r *Resource) IdFilter(id int64) *Filters {
-	f, err := r.Filters(map[string]*Filter{internal.IdFieldJsonapiName: {Eq: []string{strconv.FormatInt(id, 10)}}})
+func (r *Resource) IdFilter(id interface{}) *Filters {
+	f, err := r.Filters(map[string]*Filter{internal.IdFieldJsonapiName: {Eq: []interface{}{id}}})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/attr_field.go
+++ b/internal/attr_field.go
@@ -150,12 +150,10 @@ func newAttrField(schema *Schema, f *reflect.StructField) SchemaField {
 	field.jsonapiF = field.jsonapiAttrFields()
 	field.pgF = field.pgAttrFields()
 
-	// wrap updatedAt fields in updatedAtField struct
-	// to implement afterCreateTable
+	// wrap updatedAt fields in updatedAtField
+	// for afterCreateTable hook
 	if updatedAt {
-		return &updatedAtField{
-			field,
-		}
+		return &updatedAtField{field}
 	}
 
 	return field

--- a/internal/attr_field.go
+++ b/internal/attr_field.go
@@ -147,8 +147,8 @@ func newAttrField(schema *Schema, f *reflect.StructField) SchemaField {
 	field.validation = f.Tag.Get(validationTag)
 
 	// finally, generate jsonapi and pg attribute fields
-	field.jsonapiF = jsonapiAttrFields(field)
-	field.pgF = pgAttrFields(field)
+	field.jsonapiF = field.jsonapiAttrFields()
+	field.pgF = field.pgAttrFields()
 
 	// wrap updatedAt fields in updatedAtField struct
 	// to implement afterCreateTable
@@ -187,7 +187,7 @@ func (f *attrField) isNullable() bool {
 	return isNullable(f.fieldType) && !f.notnull
 }
 
-func jsonapiAttrFields(f *attrField) []reflect.StructField {
+func (f *attrField) jsonapiAttrFields() []reflect.StructField {
 	if f.name == unexportedFieldName {
 		return []reflect.StructField{}
 	}
@@ -212,7 +212,7 @@ func jsonapiAttrFields(f *attrField) []reflect.StructField {
 	return []reflect.StructField{field}
 }
 
-func pgAttrFields(f *attrField) []reflect.StructField {
+func (f *attrField) pgAttrFields() []reflect.StructField {
 	tag := fmt.Sprintf(`sql:"%s`, f.column)
 	if !f.isNullable() {
 		tag += ",notnull"

--- a/internal/belongs_field.go
+++ b/internal/belongs_field.go
@@ -180,8 +180,9 @@ func (i *belongsToFieldInstance) parsePGModel(instance *pgModelInstance) {
 	// if relation struct field is nil, but id field isn't,
 	// create a new instance of the model and set its id field
 	if schemaInstance == nil {
-		id := instance.value.Elem().FieldByName(i.field.relationIdFieldName()).Int()
-		if id != 0 {
+		idField := instance.value.Elem().FieldByName(i.field.relationIdFieldName())
+		id := idField.Interface()
+		if id != reflect.Zero(idField.Type()).Interface() {
 			schemaInstance = i.relationSchema.createInstance()
 			// set id field
 			for _, f := range schemaInstance.fields {
@@ -227,7 +228,7 @@ func (i *belongsToFieldInstance) parseJoinPGModel(instance *joinPGModelInstance)
 	relationInstance := i.relationSchema.createInstance()
 	for _, f := range relationInstance.fields {
 		if idField, ok := f.(*idFieldInstance); ok {
-			idField.value = idValue.Int()
+			idField.value = idValue.Interface()
 		}
 	}
 

--- a/internal/belongs_field.go
+++ b/internal/belongs_field.go
@@ -102,7 +102,17 @@ func (f *belongsToField) pgBelongsToFields(joinField bool) []reflect.StructField
 
 // relationIdFieldType returns the type of the relation's id field.
 func (f *belongsToField) relationIdFieldType() reflect.Type {
-	return f.registry[f.relationType].IdField().(*idField).fieldType
+	var schema *Schema
+	if f.schema.resourceModelType == f.relationType {
+		// if the related resource is of the same type
+		// as the resource being registered right now,
+		// it's not registered in the registry yet.
+		// therefore, get schema from field itself.
+		schema = f.schema
+	} else {
+		schema = f.registry[f.relationType]
+	}
+	return schema.IdField().(*idField).fieldType
 }
 
 // relationIdFieldName returns the name of the foreign id field.

--- a/internal/id_field.go
+++ b/internal/id_field.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding"
 	"errors"
 	"fmt"
 	"gopkg.in/go-playground/validator.v9"
@@ -8,7 +9,7 @@ import (
 )
 
 var (
-	errInvalidIdType     = errors.New("pointer types are not allowed for id fields")
+	errInvalidIdType     = errors.New("id field type must be string or non-float numeric, or implement encoding.TextMarshaler and encoding.TextUnmarshaler")
 	errNilPointer        = errors.New("resource must not be nil")
 	errMismatchingSchema = errors.New("mismatching schema")
 	emptyStructType      = reflect.TypeOf(new(struct{})).Elem()
@@ -21,8 +22,12 @@ const (
 
 // implements field
 type idField struct {
-	schema    *Schema
+	schema *Schema
+
 	fieldType reflect.Type
+	// whether the field needs to be marshalled
+	// into a string for jsonapi
+	marshalling bool
 
 	jsonapiF []reflect.StructField
 	pgF      []reflect.StructField
@@ -34,27 +39,51 @@ func newIdField(schema *Schema, f *reflect.StructField) SchemaField {
 		fieldType: f.Type,
 	}
 
-	if !isValidIdField(idf.fieldType) {
+	valid, marshalling := isValidIdField(idf.fieldType)
+	if !valid {
 		panic(errInvalidIdType)
 	}
+	idf.marshalling = marshalling
 
 	// generate jsonapi and pg attribute fields
 	idf.jsonapiF = idf.jsonapiIdFields()
 	idf.pgF = idf.pgIdFields()
 
+	// wrap id fields with uuid type in uuidIdField
+	// for afterCreateTable hook
+	if isUUIDField(idf.fieldType) {
+		return &uuidIdField{idf}
+	}
+
 	return idf
 }
 
-// isValidIdField returns whether typ is a valid type for an id field.
-func isValidIdField(typ reflect.Type) bool {
-	return typ.Kind() != reflect.Ptr
+// isValidIdField returns whether typ is a valid type for an id field
+// and whether it is a type that needs to be converted to string.
+func isValidIdField(typ reflect.Type) (bool, bool) {
+	// allow types allowed by jsonapi
+	switch reflect.New(typ).Elem().Interface().(type) {
+	case string, int, int8, int16, int32, int64, uint, uint8, uint16,
+		uint32, uint64:
+		return true, false
+	}
+
+	// allow types implementing TextMarshaler and TextUnmarshaler,
+	// as they can be easily converted to string, which is supported by jsonapi
+	return typ.Implements(reflect.TypeOf(new(encoding.TextMarshaler)).Elem()) &&
+		typ.Implements(reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()), true
 }
 
 func (f *idField) jsonapiIdFields() []reflect.StructField {
+	typ := f.fieldType
+	if f.marshalling {
+		typ = reflect.TypeOf("")
+	}
+
 	tag := fmt.Sprintf(`jsonapi:"primary,%s"`, f.schema.name)
 	idField := reflect.StructField{
 		Name: idFieldName,
-		Type: f.fieldType,
+		Type: typ,
 		Tag:  reflect.StructTag(tag),
 	}
 
@@ -69,10 +98,16 @@ func (f *idField) pgIdFields() []reflect.StructField {
 		Tag: reflect.StructTag(fmt.Sprintf(`sql:"\"%s\",alias:\"%s\""`, f.schema.table, f.schema.alias)),
 	}
 
+	pgTag := fmt.Sprintf(`sql:"%s,pk`, IdFieldColumn)
+	if isUUIDField(f.fieldType) {
+		pgTag += `,type:uuid,default:uuid_generate_v4()`
+	}
+	pgTag += `"`
+
 	idField := reflect.StructField{
 		Name: idFieldName,
 		Type: f.fieldType,
-		Tag:  reflect.StructTag(fmt.Sprintf(`sql:"%s,pk"`, IdFieldColumn)),
+		Tag:  reflect.StructTag(pgTag),
 	}
 
 	return []reflect.StructField{tableNameField, idField}
@@ -179,14 +214,42 @@ func (i *idFieldInstance) parseJsonapiModel(instance *jsonapiModelInstance) {
 	if i.field.schema != instance.schema {
 		panic(errMismatchingSchema)
 	}
-	i.parse(instance.value)
+
+	v := instance.value
+	if v.IsNil() {
+		return
+	}
+
+	val := v.Elem().FieldByName(idFieldName).Interface()
+	if i.field.marshalling {
+		// unmarshal value from string
+		val = reflect.New(i.field.fieldType).Elem().Interface()
+		val.(encoding.TextUnmarshaler).UnmarshalText([]byte(val.(string)))
+	}
+
+	i.value = val
 }
 
 func (i *idFieldInstance) applyToJsonapiModel(instance *jsonapiModelInstance) {
 	if i.field.schema != instance.schema {
 		panic(errMismatchingSchema)
 	}
-	i.apply(instance.value)
+
+	val := i.value
+	if i.field.marshalling {
+		// marshal the value into a string
+		b, err := i.value.(encoding.TextMarshaler).MarshalText()
+		if err != nil {
+			panic(err)
+		}
+		val = string(b)
+	}
+
+	v := instance.value
+	if v.IsNil() {
+		panic(errNilPointer)
+	}
+	v.Elem().FieldByName(idFieldName).Set(reflect.ValueOf(val))
 }
 
 func (i *idFieldInstance) parseJoinJsonapiModel(instance *joinJsonapiModelInstance) {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -43,11 +43,8 @@ const (
 )
 
 var (
-	idFieldType = reflect.TypeOf(int64(0))
-
 	errInvalidModelType          = errors.New("model has to be a struct")
 	errMissingIdField            = errors.New("missing id field")
-	errInvalidIdType             = errors.New("id field must be of type int")
 	errInvalidMemberName         = errors.New(`member name has to adhere to the jsonapi specification and not include characters marked as "not recommended"`)
 	errInvalidTableName          = errors.New("table name may only consist of [0-9,a-z,A-Z$_]")
 	errInvalidTableAlias         = errors.New("alias may only consist of [0-9,a-z,A-Z$_]")
@@ -103,9 +100,6 @@ func parseSchema(t reflect.Type) *Schema {
 	f, ok := t.FieldByName(idFieldName)
 	if !ok {
 		panic(errMissingIdField)
-	}
-	if f.Type != idFieldType {
-		panic(errInvalidIdType)
 	}
 
 	// parse jargo struct tag
@@ -168,7 +162,7 @@ func parseSchema(t reflect.Type) *Schema {
 // returns nil for non-attribute fields.
 func (r SchemaRegistry) parseField(schema *Schema, f *reflect.StructField) SchemaField {
 	if f.Name == idFieldName {
-		return newIdField(schema)
+		return newIdField(schema, f)
 	}
 
 	// determine field type from jargo tag

--- a/internal/schema_field.go
+++ b/internal/schema_field.go
@@ -72,6 +72,12 @@ type schemaFieldInstance interface {
 	validate(*validator.Validate) error
 }
 
+type beforeCreateTableHook interface {
+	// called on resource fields implementing beforeCreateTableHook
+	// by Resource.CreateTable() before table is created
+	beforeCreateTable(db *pg.DB) error
+}
+
 type afterCreateTableHook interface {
 	// called on resource fields implementing afterCreateTableHook
 	// by Resource.CreateTable() after table was created

--- a/internal/schema_instance.go
+++ b/internal/schema_instance.go
@@ -88,8 +88,8 @@ func (i *SchemaInstance) Validate(validate *validator.Validate) error {
 
 // GetRelationIds returns all direct (belongsTo) relations
 // to other resource schemas.
-func (i *SchemaInstance) GetRelationIds() map[*Schema][]int64 {
-	m := make(map[*Schema][]int64)
+func (i *SchemaInstance) GetRelationIds() map[*Schema][]interface{} {
+	m := make(map[*Schema][]interface{})
 
 	for _, f := range i.fields {
 		if b, ok := f.(*belongsToFieldInstance); ok {

--- a/internal/uuid_id_field.go
+++ b/internal/uuid_id_field.go
@@ -1,0 +1,14 @@
+package internal
+
+import "github.com/go-pg/pg"
+
+type uuidIdField struct {
+	*idField
+}
+
+const uuidExtensionQuery = `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
+
+func (f *uuidIdField) beforeCreateTable(db *pg.DB) error {
+	_, err := db.Exec(uuidExtensionQuery)
+	return err
+}

--- a/parser.go
+++ b/parser.go
@@ -44,9 +44,9 @@ func ParseFieldParameters(query map[string][]string) map[string][]string {
 // The resulting map can be used in Resource.ParseFilters.
 //
 // http://jsonapi.org/format/#fetching-filtering
-func ParseFilterParameters(query map[string][]string) map[string]map[string][]string {
+func ParseFilterParameters(query map[string][]string) map[string]map[string][]interface{} {
 	// map[field]map[operator][]values
-	filters := make(map[string]map[string][]string)
+	filters := make(map[string]map[string][]interface{})
 	for k, v := range query {
 		res := filterParamRegex.FindAllStringSubmatch(k, -1)
 		if res == nil {
@@ -66,12 +66,14 @@ func ParseFilterParameters(query map[string][]string) map[string]map[string][]st
 		// add values to operations
 		operations := filters[field]
 		if operations == nil {
-			operations = make(map[string][]string)
+			operations = make(map[string][]interface{})
 		}
 
-		values := make([]string, 0)
+		values := make([]interface{}, 0)
 		for _, val := range v {
-			values = append(values, strings.Split(val, ",")...)
+			for _, str := range strings.Split(val, ",") {
+				values = append(values, str)
+			}
 		}
 		operations[op] = values
 

--- a/realtime.go
+++ b/realtime.go
@@ -334,7 +334,7 @@ func (r *Realtime) handleRowUpdates(channel <-chan *pg.Notification) {
 			}
 
 			// map of all resources affected by the change
-			updated := make(map[*Resource][]int64)
+			updated := make(map[*Resource][]interface{})
 
 			// add all resources that were updated by the resources'
 			// relationships being modified
@@ -378,7 +378,7 @@ func (r *Realtime) handleRowUpdates(channel <-chan *pg.Notification) {
 				newRelations := modifiedInstance.GetRelationIds()
 
 				// create a changeset of all of the resources' relations
-				changeset := make(map[*internal.Schema][]int64)
+				changeset := make(map[*internal.Schema][]interface{})
 
 				// get all relations that were removed
 				for schema, oldIds := range oldRelations {
@@ -505,7 +505,7 @@ func (r *Realtime) onSubscribeRead(socket *glue.Socket, messageId string, data s
 }
 
 // subscribers returns all sockets that are subscribed to a resource instance.
-func (r *Realtime) subscribers(resource *Resource, id int64) []*glue.Socket {
+func (r *Realtime) subscribers(resource *Resource, id interface{}) []*glue.Socket {
 	var sockets []*glue.Socket
 	r.subscriptionsMutex.Lock()
 	for socket, subscriptions := range r.subscriptions {

--- a/resource.go
+++ b/resource.go
@@ -107,7 +107,7 @@ func (r *Resource) SelectOne(db orm.DB) *Query {
 
 // Select returns a new Select One Query
 // selecting the Resource Instance with the given id.
-func (r *Resource) SelectById(db orm.DB, id int64) *Query {
+func (r *Resource) SelectById(db orm.DB, id interface{}) *Query {
 	q := r.SelectOne(db)
 	q.Filters(r.IdFilter(id))
 	return q

--- a/test/integration/id_field_test.go
+++ b/test/integration/id_field_test.go
@@ -1,0 +1,111 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"github.com/crushedpixel/jargo"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type uuidIdField struct {
+	Id uuid.UUID
+}
+
+// TestUUID_Id tests the behaviour of UUID id fields.
+func TestUUID_Id(t *testing.T) {
+	resource, err := app.RegisterResource(uuidIdField{})
+	require.Nil(t, err)
+
+	// insert multiple instances of customIdTypeB
+	// to ensure auto-generated ids work for uuid id fields
+	for i := 0; i < 5; i++ {
+		res, err := resource.InsertInstance(app.DB(), &uuidIdField{}).Result()
+		require.Nil(t, err)
+
+		inserted := res.(*uuidIdField)
+		require.NotZero(t, inserted.Id)
+
+		// ensure instance properly encodes to json
+		json, err := resource.ResponseAllFields(inserted).Payload()
+		require.Nil(t, err)
+		require.Equal(t,
+			fmt.Sprintf(`{"data":{"type":"uuid_id_field","id":"%s"}}`, inserted.Id),
+			json)
+	}
+}
+
+type nullableIdField struct {
+	Id *int64
+}
+
+// TestNullableIdFields ensures that pointer types are not allowed for id fields.
+func TestNullableIdFields(t *testing.T) {
+	_, err := app.RegisterResource(nullableIdField{})
+	require.EqualError(t, err, "pointer types are not allowed for id fields")
+}
+
+type myString string
+type myInt int
+
+type customIdTypeA struct {
+	Id myString
+}
+
+type customIdTypeB struct {
+	Id   myInt
+	Attr string
+}
+
+// TestCustomIdTypes tests the behaviour of id fields with custom types for the id field.
+func TestCustomIdTypes(t *testing.T) {
+	resourceA, err := app.RegisterResource(customIdTypeA{})
+	require.Nil(t, err)
+
+	resourceB, err := app.RegisterResource(customIdTypeB{})
+	require.Nil(t, err)
+
+	originalA := &customIdTypeA{Id: "Marius"}
+	// insert instance of customIdTypeA
+	res, err := resourceA.InsertInstance(app.DB(), originalA).Result()
+	require.Nil(t, err)
+	inserted := res.(*customIdTypeA)
+	// ensure id was properly set
+	require.Equal(t, originalA.Id, inserted.Id)
+
+	// ensure instance properly encodes to json
+	json, err := resourceA.ResponseAllFields(inserted).Payload()
+	require.Nil(t, err)
+	require.Equal(t,
+		`{"data":{"type":"custom_id_type_as","id":"Marius"}}`,
+		json)
+
+	// insert same instance again, expecting pk constraint violation
+	_, err = resourceA.InsertInstance(app.DB(), originalA).Result()
+	// query must return UniqueViolationError
+	require.IsType(t, &jargo.UniqueViolationError{}, err)
+
+	uve := err.(*jargo.UniqueViolationError)
+	require.Equal(t, "id", uve.Column)
+	require.Equal(t, "id", uve.Field)
+
+	// insert multiple instances of customIdTypeB
+	// to ensure auto-incrementing ids work for custom number types
+	for i := 0; i < 5; i++ {
+		res, err := resourceB.InsertInstance(app.DB(), &customIdTypeB{Attr: "hi"}).Result()
+		require.Nil(t, err)
+
+		inserted := res.(*customIdTypeB)
+		require.Equal(t, i+1, inserted.Id)
+		require.Equal(t, "hi", inserted.Attr)
+
+		// ensure instance properly encodes to json
+		json, err := resourceB.ResponseAllFields(inserted).Payload()
+		require.Nil(t, err)
+		require.Equal(t,
+			fmt.Sprintf(`{"data":{"type":"custom_id_type_bs","id":"%d","attributes":{"attr":"hi"}}}`, i+1),
+			json)
+	}
+}

--- a/test/integration/id_field_test.go
+++ b/test/integration/id_field_test.go
@@ -10,6 +10,34 @@ import (
 	"testing"
 )
 
+type autoIncrementingIdField struct {
+	Id int64
+}
+
+// TestAutoIncrementingIdField tests the behaviour
+// of auto-incrementing id fields.
+func TestAutoIncrementingIdField(t *testing.T) {
+	resource, err := app.RegisterResource(autoIncrementingIdField{})
+	require.Nil(t, err)
+
+	// insert multiple instances of customIdTypeB
+	// to ensure auto-incrementing ids work for custom number types
+	for i := 0; i < 5; i++ {
+		res, err := resource.InsertInstance(app.DB(), &autoIncrementingIdField{}).Result()
+		require.Nil(t, err)
+
+		inserted := res.(*autoIncrementingIdField)
+		require.Equal(t, int64(i+1), inserted.Id)
+
+		// ensure instance properly encodes to json
+		json, err := resource.ResponseAllFields(inserted).Payload()
+		require.Nil(t, err)
+		require.Equal(t,
+			fmt.Sprintf(`{"data":{"type":"auto_incrementing_id_fields","id":"%d"}}`, i+1),
+			json)
+	}
+}
+
 type uuidIdField struct {
 	Id uuid.UUID
 }

--- a/test/integration/relationships_test.go
+++ b/test/integration/relationships_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type oneToManyA struct {
-	Id   int64
+	Id   string
 	Attr string
 	Bs   []oneToManyB `jargo:",has:A"`
 }
@@ -26,7 +26,7 @@ func TestOneToManyRelations(t *testing.T) {
 	require.Nil(t, err)
 
 	// create instance of oneToManyA
-	res, err := resourceA.InsertInstance(app.DB(), &oneToManyA{Attr: "test"}).Result()
+	res, err := resourceA.InsertInstance(app.DB(), &oneToManyA{Id: "parent", Attr: "test"}).Result()
 	require.Nil(t, err)
 	a := res.(*oneToManyA)
 
@@ -34,7 +34,7 @@ func TestOneToManyRelations(t *testing.T) {
 	json, err := resourceA.ResponseAllFields(a).Payload()
 	require.Nil(t, err)
 	require.Equal(t,
-		`{"data":{"type":"one_to_many_as","id":"1","attributes":{"attr":"test"},"relationships":{"bs":{"data":[]}}}}`,
+		`{"data":{"type":"one_to_many_as","id":"parent","attributes":{"attr":"test"},"relationships":{"bs":{"data":[]}}}}`,
 		json)
 
 	// create instance of oneToManyB with relation to a
@@ -50,7 +50,7 @@ func TestOneToManyRelations(t *testing.T) {
 	json, err = resourceB.ResponseAllFields(b).Payload()
 	require.Nil(t, err)
 	require.Equal(t,
-		`{"data":{"type":"one_to_many_bs","id":"1","relationships":{"a":{"data":{"type":"one_to_many_as","id":"1"}}}}}`,
+		`{"data":{"type":"one_to_many_bs","id":"1","relationships":{"a":{"data":{"type":"one_to_many_as","id":"parent"}}}}}`,
 		json)
 
 	// fetch oneToManyA to update relations
@@ -65,7 +65,7 @@ func TestOneToManyRelations(t *testing.T) {
 	json, err = resourceA.ResponseAllFields(a).Payload()
 	require.Nil(t, err)
 	require.Equal(t,
-		`{"data":{"type":"one_to_many_as","id":"1","attributes":{"attr":"test"},"relationships":{"bs":{"data":[{"type":"one_to_many_bs","id":"1"}]}}}}`,
+		`{"data":{"type":"one_to_many_as","id":"parent","attributes":{"attr":"test"},"relationships":{"bs":{"data":[{"type":"one_to_many_bs","id":"1"}]}}}}`,
 		json)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -12,12 +12,12 @@ func escapePGColumn(field string) string {
 
 // difference returns the elements in a that aren't in b.
 // Modified from https://stackoverflow.com/a/45428032/2733724
-func difference(a, b []int64) []int64 {
-	mb := make(map[int64]bool)
+func difference(a, b []interface{}) []interface{} {
+	mb := make(map[interface{}]bool)
 	for _, x := range b {
 		mb[x] = true
 	}
-	var ab []int64
+	var ab []interface{}
 	for _, x := range a {
 		if _, ok := mb[x]; !ok {
 			ab = append(ab, x)


### PR DESCRIPTION
- Added support for all id field types supported by [`google/jsonapi`](https://github.com/google/jsonapi).
- Added support for id field types that implement `encoding.TextMarshaler` and `encoding.TextUnmarshaler`. These types are being converted to `string`s internally to satisfy `jsonapi`.
- Set default value of `UUID` types on id fields to `uuid_generate_v4()` (from [`uuid-ossp`](https://www.postgresql.org/docs/9.4/static/uuid-ossp.html) PostgreSQL extension)

Closes #20.